### PR TITLE
Filter virtual block devices via configurable storage_exclude

### DIFF
--- a/src/collectors/storage.rs
+++ b/src/collectors/storage.rs
@@ -2,7 +2,7 @@ use crate::model::storage::{NvmeDetails, SmartData, StorageDevice, StorageInterf
 use crate::platform::{nvme_ioctl, sata_ioctl, sysfs};
 use std::path::Path;
 
-pub fn collect() -> Vec<StorageDevice> {
+pub fn collect(storage_exclude: &[String]) -> Vec<StorageDevice> {
     let mut devices = Vec::new();
 
     for entry in sysfs::glob_paths("/sys/class/block/*") {
@@ -11,13 +11,10 @@ pub fn collect() -> Vec<StorageDevice> {
             None => continue,
         };
 
-        // Skip partitions, loop, dm, ram, zram devices
-        if name.starts_with("loop")
-            || name.starts_with("dm-")
-            || name.starts_with("ram")
-            || name.starts_with("zram")
-            || name.starts_with("sr")
-            || name.starts_with("nbd")
+        // Skip virtual/pseudo devices by configurable prefix list
+        if storage_exclude
+            .iter()
+            .any(|prefix| name.starts_with(prefix.as_str()))
         {
             continue;
         }
@@ -43,7 +40,8 @@ impl crate::collectors::Collector for StorageCollector {
     }
 
     fn collect_into(&self, info: &mut crate::model::system::SystemInfo) {
-        info.storage = collect();
+        let defaults = crate::config::GeneralConfig::default().storage_exclude;
+        info.storage = collect(&defaults);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,9 @@ pub struct GeneralConfig {
     pub no_nvidia: bool,
     #[serde(default = "default_color")]
     pub color: String,
+    /// Block device name prefixes to exclude from storage listings and disk sensors.
+    #[serde(default = "default_storage_exclude")]
+    pub storage_exclude: Vec<String>,
 }
 
 fn default_format() -> String {
@@ -37,6 +40,12 @@ fn default_true() -> bool {
 fn default_color() -> String {
     "auto".into()
 }
+fn default_storage_exclude() -> Vec<String> {
+    ["loop", "dm-", "ram", "zram", "sr", "nbd", "zd", "md"]
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect()
+}
 
 impl Default for GeneralConfig {
     fn default() -> Self {
@@ -46,6 +55,7 @@ impl Default for GeneralConfig {
             physical_net_only: default_true(),
             no_nvidia: false,
             color: default_color(),
+            storage_exclude: default_storage_exclude(),
         }
     }
 }
@@ -105,6 +115,8 @@ mod tests {
         assert!(cfg.general.physical_net_only);
         assert!(!cfg.general.no_nvidia);
         assert_eq!(cfg.general.color, "auto");
+        assert!(cfg.general.storage_exclude.contains(&"zd".to_string()));
+        assert!(cfg.general.storage_exclude.contains(&"loop".to_string()));
         assert!(cfg.sensor_labels.is_empty());
     }
 
@@ -125,6 +137,7 @@ poll_interval_ms = 500
 physical_net_only = false
 no_nvidia = true
 color = "never"
+storage_exclude = ["loop", "zd", "custom"]
 
 [sensor_labels]
 "hwmon/nct6798/in0" = "Vcore"
@@ -136,6 +149,7 @@ color = "never"
         assert!(!cfg.general.physical_net_only);
         assert!(cfg.general.no_nvidia);
         assert_eq!(cfg.general.color, "never");
+        assert_eq!(cfg.general.storage_exclude, vec!["loop", "zd", "custom"]);
         assert_eq!(cfg.sensor_labels.get("hwmon/nct6798/in0").unwrap(), "Vcore");
         assert_eq!(
             cfg.sensor_labels.get("hwmon/nct6798/fan1").unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,18 +33,18 @@ fn main() {
 
     // TUI monitor mode
     if cli.tui {
-        run_monitor(&cli, label_overrides);
+        run_monitor(&cli, &config, label_overrides);
         return;
     }
 
     // Sensor snapshot or one-shot commands
     if let Some(Commands::Sensors) = &cli.command {
-        run_sensor_snapshot(&cli, &label_overrides);
+        run_sensor_snapshot(&cli, &config, &label_overrides);
         return;
     }
 
     // Standard hardware info collection
-    let info = collect_all(&cli);
+    let info = collect_all(&cli, &config);
 
     let print_formatted = |info: &SystemInfo| match cli.format {
         #[cfg(feature = "json")]
@@ -87,7 +87,11 @@ fn main() {
     }
 }
 
-fn run_monitor(cli: &Cli, label_overrides: std::collections::HashMap<String, String>) {
+fn run_monitor(
+    cli: &Cli,
+    config: &config::SiomonConfig,
+    label_overrides: std::collections::HashMap<String, String>,
+) {
     #[cfg(feature = "tui")]
     {
         let state = sensors::poller::new_state();
@@ -99,6 +103,7 @@ fn run_monitor(cli: &Cli, label_overrides: std::collections::HashMap<String, Str
             cli.no_nvidia,
             cli.direct_io,
             label_overrides,
+            config.general.storage_exclude.clone(),
         );
         let _handle = poller.spawn();
 
@@ -137,13 +142,22 @@ fn run_monitor(cli: &Cli, label_overrides: std::collections::HashMap<String, Str
 
     #[cfg(not(feature = "tui"))]
     {
-        let _ = (cli, label_overrides);
+        let _ = (cli, config, label_overrides);
         eprintln!("TUI not available — compile with the 'tui' feature");
     }
 }
 
-fn run_sensor_snapshot(cli: &Cli, label_overrides: &std::collections::HashMap<String, String>) {
-    let readings = sensors::poller::snapshot(cli.no_nvidia, cli.direct_io, label_overrides);
+fn run_sensor_snapshot(
+    cli: &Cli,
+    config: &config::SiomonConfig,
+    label_overrides: &std::collections::HashMap<String, String>,
+) {
+    let readings = sensors::poller::snapshot(
+        cli.no_nvidia,
+        cli.direct_io,
+        label_overrides,
+        &config.general.storage_exclude,
+    );
     let mut sorted: Vec<_> = readings.into_iter().collect();
     sorted.sort_by(|a, b| a.0.natural_cmp(&b.0));
 
@@ -198,8 +212,9 @@ fn join_or_default<T: Default>(result: std::thread::Result<T>, name: &str) -> T 
     }
 }
 
-fn collect_all(cli: &Cli) -> SystemInfo {
+fn collect_all(cli: &Cli, config: &config::SiomonConfig) -> SystemInfo {
     let no_nvidia = cli.no_nvidia;
+    let storage_exclude = config.general.storage_exclude.clone();
 
     let hostname =
         platform::sysfs::read_string_optional(std::path::Path::new("/proc/sys/kernel/hostname"))
@@ -223,7 +238,7 @@ fn collect_all(cli: &Cli) -> SystemInfo {
             let h_mem = s.spawn(collectors::memory::collect);
             let h_board = s.spawn(collectors::motherboard::collect);
             let h_gpu = s.spawn(move || collectors::gpu::collect(no_nvidia));
-            let h_stor = s.spawn(collectors::storage::collect);
+            let h_stor = s.spawn(|| collectors::storage::collect(&storage_exclude));
             let h_net = s.spawn(|| collectors::network::collect(true));
             let h_pci = s.spawn(collectors::pci::collect);
             let h_audio = s.spawn(collectors::audio::collect);

--- a/src/sensors/disk_activity.rs
+++ b/src/sensors/disk_activity.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 pub struct DiskActivitySource {
     prev_stats: HashMap<String, DiskStat>,
     prev_time: Instant,
+    storage_exclude: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -16,16 +17,17 @@ struct DiskStat {
 }
 
 impl DiskActivitySource {
-    pub fn discover() -> Self {
-        let prev_stats = parse_diskstats();
+    pub fn discover(storage_exclude: &[String]) -> Self {
+        let prev_stats = parse_diskstats(storage_exclude);
         Self {
             prev_stats,
             prev_time: Instant::now(),
+            storage_exclude: storage_exclude.to_vec(),
         }
     }
 
     pub fn poll(&mut self) -> Vec<(SensorId, SensorReading)> {
-        let current = parse_diskstats();
+        let current = parse_diskstats(&self.storage_exclude);
         let now = Instant::now();
         let elapsed_secs = now.duration_since(self.prev_time).as_secs_f64();
         let mut readings = Vec::new();
@@ -97,7 +99,7 @@ impl crate::sensors::SensorSource for DiskActivitySource {
     }
 }
 
-fn parse_diskstats() -> HashMap<String, DiskStat> {
+fn parse_diskstats(storage_exclude: &[String]) -> HashMap<String, DiskStat> {
     let mut stats = HashMap::new();
     let Ok(content) = fs::read_to_string("/proc/diskstats") else {
         return stats;
@@ -113,8 +115,8 @@ fn parse_diskstats() -> HashMap<String, DiskStat> {
 
         let device = fields[2];
 
-        // Filter to real block devices: skip partitions (e.g. sda1), loop, ram, dm devices
-        if !is_real_block_device(device) {
+        // Filter to real block devices: skip partitions (e.g. sda1) and excluded prefixes
+        if !is_real_block_device(device, storage_exclude) {
             continue;
         }
 
@@ -139,9 +141,12 @@ fn parse_diskstats() -> HashMap<String, DiskStat> {
     stats
 }
 
-fn is_real_block_device(name: &str) -> bool {
-    // Skip loop, ram, and dm- devices
-    if name.starts_with("loop") || name.starts_with("ram") || name.starts_with("dm-") {
+fn is_real_block_device(name: &str, storage_exclude: &[String]) -> bool {
+    // Skip devices matching configurable exclude prefixes
+    if storage_exclude
+        .iter()
+        .any(|prefix| name.starts_with(prefix.as_str()))
+    {
         return false;
     }
 

--- a/src/sensors/poller.rs
+++ b/src/sensors/poller.rs
@@ -34,6 +34,7 @@ pub struct Poller {
     no_nvidia: bool,
     direct_io: bool,
     label_overrides: HashMap<String, String>,
+    storage_exclude: Vec<String>,
 }
 
 impl Poller {
@@ -44,6 +45,7 @@ impl Poller {
         no_nvidia: bool,
         direct_io: bool,
         label_overrides: HashMap<String, String>,
+        storage_exclude: Vec<String>,
     ) -> Self {
         Self {
             state,
@@ -52,6 +54,7 @@ impl Poller {
             no_nvidia,
             direct_io,
             label_overrides,
+            storage_exclude,
         }
     }
 
@@ -71,8 +74,12 @@ impl Poller {
     }
 
     fn run(self, stop: Arc<std::sync::atomic::AtomicBool>) {
-        let mut sources =
-            discover_all_sources(self.no_nvidia, self.direct_io, &self.label_overrides);
+        let mut sources = discover_all_sources(
+            self.no_nvidia,
+            self.direct_io,
+            &self.label_overrides,
+            &self.storage_exclude,
+        );
 
         log::info!("Sensor poller started: {} sources", sources.len());
 
@@ -171,6 +178,7 @@ fn discover_all_sources(
     no_nvidia: bool,
     direct_io: bool,
     label_overrides: &HashMap<String, String>,
+    storage_exclude: &[String],
 ) -> Vec<Box<dyn SensorSource>> {
     use std::thread;
     use std::time::Instant;
@@ -259,7 +267,7 @@ fn discover_all_sources(
             Box::new(cpu_freq::CpuFreqSource::discover()),
             Box::new(cpu_util::CpuUtilSource::discover()),
             Box::new(rapl::RaplSource::discover()),
-            Box::new(disk_activity::DiskActivitySource::discover()),
+            Box::new(disk_activity::DiskActivitySource::discover(storage_exclude)),
             Box::new(network_stats::NetworkStatsSource::discover()),
             Box::new(super::edac::EdacSource::discover()),
             Box::new(super::aer::AerSource::discover()),
@@ -294,8 +302,9 @@ pub fn snapshot(
     no_nvidia: bool,
     direct_io: bool,
     label_overrides: &HashMap<String, String>,
+    storage_exclude: &[String],
 ) -> HashMap<SensorId, SensorReading> {
-    let mut sources = discover_all_sources(no_nvidia, direct_io, label_overrides);
+    let mut sources = discover_all_sources(no_nvidia, direct_io, label_overrides, storage_exclude);
 
     // Short sleep for delta-based sources to have meaningful deltas
     thread::sleep(Duration::from_millis(250));


### PR DESCRIPTION
Add storage_exclude config option (prefix list) that controls which block devices are hidden from both storage listings and disk sensors. Defaults include loop, dm-, ram, zram, sr, nbd, zd, md — adding zd (ZFS zvols) and md (mdraid) which were previously shown.

Users can customize via config.toml:
  [general]
  storage_exclude = ["loop", "dm-", "ram", "zram", "sr", "nbd", "zd", "md"]

Fixes #13