### PR TITLE
Add Nix flake for NixOS/nix-based builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,98 @@
+{
+  description = "siomon - Linux hardware information and real-time sensor monitoring tool";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      # siomon is Linux-only (reads /sys, /proc, ioctls, etc.)
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+    in
+    flake-utils.lib.eachSystem supportedSystems (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        # Factory function: build sinfo_io.ko against any kernel
+        mkSinfoIoKmod = kernel: pkgs.stdenv.mkDerivation {
+          pname = "sinfo-io";
+          version = "0.1.0";
+          src = ./kmod/sinfo_io;
+
+          nativeBuildInputs = kernel.moduleBuildDependencies;
+
+          makeFlags = [
+            "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+          ];
+
+          installPhase = ''
+            runHook preInstall
+            install -D sinfo_io.ko \
+              "$out/lib/modules/${kernel.modDirVersion}/extra/sinfo_io.ko"
+            runHook postInstall
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Kernel module for siomon atomic Super I/O register access";
+            longDescription = ''
+              Optional kernel module that provides a /dev/sinfo_io character device for
+              atomic banked register reads on Nuvoton NCT67xx and ITE IT87xx Super I/O
+              hardware monitoring chips, avoiding race conditions with the in-kernel
+              nct6775/it87 hwmon drivers.
+            '';
+            license = licenses.gpl2Only;
+            platforms = platforms.linux;
+          };
+        };
+      in
+      {
+        # ── Packages ──────────────────────────────────────────────────────────
+        packages = {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "siomon";
+            version = "0.2.2";
+            src = ./.;
+
+            # Reads Cargo.lock directly; no cargoHash required.
+            cargoLock.lockFile = ./Cargo.lock;
+
+            meta = with pkgs.lib; {
+              description = "Linux hardware information and real-time sensor monitoring";
+              longDescription = ''
+                siomon is a zero-runtime-dependency binary for Linux that reports
+                detailed CPU, memory, GPU, storage, network, audio, USB, battery,
+                PCIe, and SMBIOS/DMI hardware information.  It also offers an
+                interactive TUI dashboard for real-time hwmon / RAPL / GPU sensor
+                monitoring with configurable alerts and CSV logging.
+                The binary is called `sio`.
+              '';
+              homepage = "https://github.com/level1techs/siomon";
+              license = licenses.mit;
+              maintainers = [ ];
+              platforms = platforms.linux;
+              mainProgram = "sio";
+            };
+          };
+
+          # sinfo_io kernel module built against the default system kernel.
+          # For other kernels use `packages.${system}.lib.mkSinfoIoKmod`.
+          sinfo-io-kmod = mkSinfoIoKmod pkgs.linuxPackages.kernel;
+        };
+
+        # ── Library outputs ───────────────────────────────────────────────────
+        # Expose the module factory so downstream flakes can build against any
+        # kernel: `inputs.siomon.lib.x86_64-linux.mkSinfoIoKmod pkgs.linuxPackages_latest.kernel`
+        lib.mkSinfoIoKmod = mkSinfoIoKmod;
+      }
+    )
+
+    # ── System-independent outputs ─────────────────────────────────────────
+    // {
+      # Nixpkgs overlay: adds `pkgs.siomon`
+      overlays.default = final: _prev: {
+        siomon = self.packages.${final.stdenv.hostPlatform.system}.default;
+      };
+    };
+}


### PR DESCRIPTION
Adds `flake.nix` and `flake.lock` so siomon can be built and used on NixOS or any system with Nix, without manual setup.

  ## Flake outputs

  | Output | Description |
  |--------|-------------|
  | `packages.{x86_64,aarch64}-linux.default` | The `sio` binary |
  | `packages.{x86_64,aarch64}-linux.sinfo-io-kmod` | `sinfo_io.ko` against the default nixpkgs kernel |
  | `overlays.default` | Adds `pkgs.siomon` to a nixpkgs instance |
  | `lib.{system}.mkSinfoIoKmod` | Factory to build `sinfo_io.ko` against any kernel |

## Usage

Run without installing:

`nix run github:level1techs/siomon`

Use the overlay in a NixOS or home-manager config:

```
nixpkgs.overlays = [ inputs.siomon.overlays.default ];
```

## Notes

- `cargoLock.lockFile = ./Cargo.lock` is used instead of `cargoHash`,
  so no hash needs updating when dependencies change.
- `nixpkgs-unstable` is required; Rust ≥ 1.85 is not yet
  in a stable nixpkgs channel.


## Flake maintenance
Maintenance of flake is minimal since only version string is required to match the Cargo.toml version