### PR TITLE
Wire up AUR publish in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,3 +78,14 @@ jobs:
         with:
           generate_release_notes: true
           files: artifacts/**/*.tar.gz
+
+  publish-aur:
+    name: Publish to AUR
+    needs: [github-release]
+    uses: ./.github/workflows/publish-aur.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets:
+      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+      PKG_GIT_NAME: ${{ secrets.PKG_GIT_NAME }}
+      PKG_GIT_EMAIL: ${{ secrets.PKG_GIT_EMAIL }}


### PR DESCRIPTION
## Summary
- The AUR publish workflow (#27) supports `workflow_call` but was never wired into the release pipeline
- Adds a `publish-aur` job to `release.yml` that runs after `github-release` completes, passing the tag and required secrets