### PR TITLE
Exclude non Rust code from Cargo build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 keywords = ["hardware", "sensors", "hwmon", "system-info", "monitoring"]
 categories = ["command-line-utilities", "hardware-support"]
 repository = "https://github.com/level1techs/siomon"
+exclude = ["packaging/", "assets/", "kmod/", ".github/", "CONTRIBUTING.md", "PACKAGING.md", "cliff.toml"]
 
 [[bin]]
 name = "sio"


### PR DESCRIPTION
We don't need these files/directories during the cargo build

Cargo docs on `exclude`:
https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields