### PR TITLE
Add module-level doc comments to all top-level src modules

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,5 @@
+//! Command-line argument parsing and config-file application.
+
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::config::SiomonConfig;

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -1,3 +1,9 @@
+//! One-shot hardware information collectors.
+//!
+//! Each submodule queries a specific hardware subsystem (CPU, GPU, memory, etc.)
+//! and populates [`SystemInfo`] fields. All collectors run in parallel during a
+//! full system scan.
+
 pub mod audio;
 pub mod battery;
 pub mod cpu;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+//! Configuration file loading and management (`~/.config/siomon/config.toml`).
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,9 @@
+//! Embedded lookup databases.
+//!
+//! Static reference data compiled into the binary: CPU codenames, per-board
+//! sensor label/template mappings, MCE error descriptions, and voltage scaling
+//! tables. Board templates are organized by vendor under `boards/`.
+
 pub mod boards;
 pub mod cpu_codenames;
 pub mod mce;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+//! Error types (`SiomonError`, `NvmlError`) and the crate-level `Result` alias.
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,20 @@
+/// Command-line argument parsing and config application (clap).
 pub mod cli;
+/// One-shot hardware information collectors (`Collector` trait).
 pub mod collectors;
+/// Configuration file loading (`~/.config/siomon/config.toml`).
 pub mod config;
+/// Embedded lookup databases (CPU codenames, board templates, sensor labels).
 pub mod db;
+/// Error types (`SiomonError`, `NvmlError`).
 pub mod error;
+/// Shared data structures for hardware and sensor information.
 pub mod model;
+/// Output formatters (text, JSON, XML, HTML, CSV) and the TUI dashboard.
 pub mod output;
+/// Binary format parsers (SMBIOS, EDID).
 pub mod parsers;
+/// OS and hardware I/O abstractions (sysfs, procfs, MSR, NVMe/SATA ioctl, port I/O, NVML, Tegra).
 pub mod platform;
+/// Real-time sensor polling sources (`SensorSource` trait).
 pub mod sensors;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,3 +1,8 @@
+//! Shared data structures for hardware and sensor information.
+//!
+//! Serde-serializable types used by collectors, sensors, and output formatters.
+//! [`system::SystemInfo`] is the top-level container populated during collection.
+
 pub mod audio;
 pub mod battery;
 pub mod cpu;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,3 +1,8 @@
+//! Output formatters and the TUI dashboard.
+//!
+//! Each submodule renders [`SystemInfo`](crate::model::system::SystemInfo) in a
+//! different format. Most are feature-gated; `text` is always available.
+
 #[cfg(feature = "csv")]
 pub mod csv;
 #[cfg(feature = "html")]

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -1,2 +1,4 @@
+//! Binary format parsers for hardware data (SMBIOS tables, EDID blocks).
+
 pub mod edid;
 pub mod smbios;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,3 +1,9 @@
+//! OS and hardware I/O abstractions.
+//!
+//! Low-level interfaces to Linux subsystems: sysfs, procfs, MSR reads,
+//! NVMe/SATA ioctls, direct port I/O, the `sinfo_io` kernel module,
+//! NVML (NVIDIA), and Tegra devfreq/engine sensors.
+
 pub mod msr;
 pub mod nvme_ioctl;
 #[cfg(feature = "nvidia")]

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -1,3 +1,9 @@
+//! Real-time sensor polling sources.
+//!
+//! Most submodules implement [`SensorSource`] for a specific data source
+//! (hwmon, IPMI, RAPL, Super I/O, I2C/PMBus, etc.). The [`poller`] module
+//! orchestrates all discovered sources in a background thread.
+
 pub mod aer;
 pub mod alerts;
 pub mod cpu_freq;


### PR DESCRIPTION
## Summary

- Adds `//!` inner doc comments to all 10 top-level modules under `src/` (`cli`, `collectors`, `config`, `db`, `error`, `model`, `output`, `parsers`, `platform`, `sensors`) and outer `///` doc comments on the `lib.rs` re-exports.
- Makes the claim in #43 ("each top-level module has a doc comment or mod.rs explaining its role") accurate.