### PR TITLE
Userspace sensor permissions via udev and setcap

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -102,6 +102,7 @@ jobs:
           useradd -m builder
 
           cp packaging/aur/PKGBUILD /home/builder/PKGBUILD
+          cp packaging/aur/siomon.install /home/builder/siomon.install
           cd /home/builder
 
           # Update version fields
@@ -109,7 +110,7 @@ jobs:
           sed -i "s/^_tag=.*/_tag=${COMMIT_HASH} # git rev-parse \"v\$pkgver\"/" PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=${PKGREL}/" PKGBUILD
 
-          chown builder:builder PKGBUILD
+          chown builder:builder PKGBUILD siomon.install
 
           # Recompute checksums
           echo "==> Recomputing b2sums..."
@@ -166,8 +167,9 @@ jobs:
 
           cp /home/builder/PKGBUILD .
           cp /home/builder/.SRCINFO .
+          cp /home/builder/siomon.install .
 
-          git add PKGBUILD .SRCINFO
+          git add PKGBUILD .SRCINFO siomon.install
           if git diff --cached --quiet; then
             echo "No changes to push."
           else

--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -237,6 +237,10 @@ jobs:
             # per series (e.g. Noble uses versioned cargo-1.85/rustc-1.85).
             cp -r "$GITHUB_WORKSPACE/packaging/launchpad/debian" "$BUILD_DIR/debian"
 
+            # Canonical udev/tmpfiles live in packaging/ — copy for debhelper
+            cp "$GITHUB_WORKSPACE/packaging/udev/50-siomon.rules" "$BUILD_DIR/debian/siomon.udev"
+            cp "$GITHUB_WORKSPACE/packaging/tmpfiles/siomon.conf" "$BUILD_DIR/debian/siomon.tmpfiles"
+
             # Write series-specific changelog
             # Changelog format: header at col 0, bullets at 2-space indent, trailer " -- "
             {
@@ -248,8 +252,8 @@ jobs:
               echo " -- ${PKG_GIT_NAME} <${PKG_GIT_EMAIL}>  $(date -R)"
             } > "$BUILD_DIR/debian/changelog"
 
-            # Adjust Build-Depends for series
-            sed -i "s/Build-Depends: debhelper-compat (= 13), cargo, rustc (>= 1.85)/Build-Depends: debhelper-compat (= 13), ${RUST_PKGS}/" \
+            # Adjust Build-Depends for series (replace cargo/rustc, keep other deps)
+            sed -i "s/cargo, rustc (>= 1.85)/${RUST_PKGS}/" \
               "$BUILD_DIR/debian/control"
 
             # Adjust cargo binary name in rules

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -9,8 +9,13 @@ pkgdesc="Hardware information and real-time sensor monitoring tool"
 arch=(x86_64 aarch64)
 url="https://github.com/level1techs/siomon"
 license=('MIT')
+# libcap: provides setcap(8), used by siomon.install post_install() to grant
+#   cap_perfmon (perf_event_open for L3 cache hit rate) and cap_sys_rawio
+#   (direct I/O port access for Super I/O chips) on the sio binary, so
+#   sensors work without running as root.
 depends=('glibc'
-         'libgcc')
+         'libgcc'
+         'libcap')
 optdepends=('nvidia-utils: GPU name, VRAM, clocks, temp, power, utilization'
             'dmidecode: Per-DIMM memory details'
             'msr-tools: CPU TDP, turbo ratios, C-states, perf limiters'
@@ -18,6 +23,10 @@ optdepends=('nvidia-utils: GPU name, VRAM, clocks, temp, power, utilization'
             'hddtemp: SATA drive temperatures via hwmon')
 makedepends=('git'
              'cargo')
+# siomon.install hooks:
+#   post_install: setcap on the binary (udev/tmpfiles already handled by pre-existing libalpm hooks shipped by default on any Arch system)
+#   post_upgrade: same as post_install
+install=siomon.install
 options=()
 _tag=2f0b399085de511ff14d8a8a2b69c71f7a40558c # git rev-parse "v$pkgver"
 source=("siomon::git+https://github.com/level1techs/siomon.git#tag=$_tag")
@@ -48,4 +57,12 @@ package() {
     export RUSTUP_TOOLCHAIN=stable
     cargo install --no-track --frozen --all-features --root "$pkgdir/usr/" --path .
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+    # udev: TAG+="uaccess" for sensor device nodes (no group needed)
+    install -Dm644 packaging/udev/50-siomon.rules \
+        "$pkgdir/usr/lib/udev/rules.d/50-siomon.rules"
+
+    # tmpfiles.d: RAPL sysfs is 0400 root — make world-readable at boot
+    install -Dm644 packaging/tmpfiles/siomon.conf \
+        "$pkgdir/usr/lib/tmpfiles.d/siomon.conf"
 }

--- a/packaging/aur/siomon.install
+++ b/packaging/aur/siomon.install
@@ -1,0 +1,15 @@
+# udev (TAG+="uaccess") and tmpfiles.d (RAPL sysfs) are handled by
+# libalpm hooks. Only setcap needs to be done explicitly.
+#
+# udev reload and tmpfiles --create are triggered automatically by
+# existing libalpm hooks when files land in /usr/lib/udev/rules.d/
+# and /usr/lib/tmpfiles.d/ — do not add them here.
+
+post_install() {
+    setcap cap_perfmon,cap_sys_rawio=ep /usr/bin/sio
+    echo ">> For resctrl (LLC/MBM): mount -t resctrl resctrl /sys/fs/resctrl"
+}
+
+post_upgrade() {
+    post_install
+}

--- a/packaging/launchpad/debian/control
+++ b/packaging/launchpad/debian/control
@@ -2,16 +2,29 @@ Source: siomon
 Section: utils
 Priority: optional
 Maintainer: Level1Techs Package Team <level1techspackageteam@gmail.com>
-Build-Depends: debhelper-compat (= 13), cargo, rustc (>= 1.85)
+# libcap2-bin: provides setcap(8), used in override_dh_fixperms to set
+#   cap_perfmon + cap_sys_rawio on the sio binary so sensors work without root.
+#   Also needed at build time because dh_fixperms strips capabilities and we
+#   must re-apply them before the .deb is assembled.
+Build-Depends: debhelper-compat (= 13), cargo, rustc (>= 1.85), libcap2-bin
 Standards-Version: 4.6.2
 Homepage: https://github.com/level1techs/siomon
 Vcs-Git: https://github.com/level1techs/siomon.git
 Vcs-Browser: https://github.com/level1techs/siomon
-Rules-Requires-Root: no
+# Rules-Requires-Root: yes is required — not optional. override_dh_fixperms
+# calls setcap(8) which needs CAP_SETFCAP (i.e. root). With "no", debhelper
+# does not run the override as root; setcap silently fails and the packaged
+# binary has no capabilities. postinst re-applies setcap at install time,
+# but the build artifact itself would be wrong.
+Rules-Requires-Root: yes
 
 Package: siomon
 Architecture: amd64 arm64
-Depends: ${shlibs:Depends}, ${misc:Depends}
+# libcap2-bin: runtime dependency — postinst re-applies setcap on the binary
+#   after each install/upgrade. Sensor device access is handled by udev rules
+#   (TAG+="uaccess" via siomon.udev) and RAPL sysfs permissions by
+#   systemd-tmpfiles (siomon.tmpfiles). No custom groups required.
+Depends: ${shlibs:Depends}, ${misc:Depends}, libcap2-bin
 Description: Linux hardware information and sensor monitoring tool
  siomon provides comprehensive Linux hardware information and real-time
  sensor monitoring as a single static binary. It supports detailed hardware

--- a/packaging/launchpad/debian/postinst
+++ b/packaging/launchpad/debian/postinst
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# udev (TAG+="uaccess") and tmpfiles.d (RAPL sysfs) are handled by
+# debhelper via #DEBHELPER# below. Only setcap needs to be done explicitly.
+#
+# udev reload and tmpfiles --create are injected automatically by
+# dh_installudev and dh_installtmpfiles into #DEBHELPER# below
+# — do not add them here.
+
+case "$1" in
+    configure)
+        setcap cap_perfmon,cap_sys_rawio=ep /usr/bin/sio
+        ;;
+esac
+
+#DEBHELPER#

--- a/packaging/launchpad/debian/rules
+++ b/packaging/launchpad/debian/rules
@@ -25,6 +25,13 @@ override_dh_auto_clean:
 override_dh_clean:
 	dh_clean -Xvendor
 
+# Rules-Requires-Root: yes (in debian/control) ensures this override runs as
+# root. setcap(8) requires CAP_SETFCAP — without root the call silently fails.
+override_dh_fixperms:
+	dh_fixperms
+	# dh_fixperms strips file capabilities — re-apply them
+	setcap cap_perfmon,cap_sys_rawio=ep debian/siomon/usr/bin/sio
+
 # --ignore-missing-info: vendored crate build artifacts lack dpkg shlibdeps metadata
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info

--- a/packaging/tmpfiles/siomon.conf
+++ b/packaging/tmpfiles/siomon.conf
@@ -1,0 +1,10 @@
+# siomon — make RAPL energy counters world-readable
+# Applied at boot by systemd-tmpfiles --create
+#
+# Covers both Intel and AMD: AMD RAPL support is implemented in
+# drivers/powercap/intel_rapl_msr.c (there is no separate amd_rapl driver)
+# and registers zones under the same "intel-rapl" control type. AMD platforms
+# therefore expose /sys/class/powercap/intel-rapl:* identical to Intel.
+# There are no amd-rapl:* or amd_rapl:* sysfs paths on any current kernel.
+z /sys/class/powercap/intel-rapl:*/energy_uj 0444 root root -
+z /sys/class/powercap/intel-rapl:*/max_energy_range_uj 0444 root root -

--- a/packaging/udev/50-siomon.rules
+++ b/packaging/udev/50-siomon.rules
@@ -1,0 +1,24 @@
+# siomon — grant logged-in user access to sensor devices
+# TAG+="uaccess" sets a POSIX ACL via systemd-logind,
+# no group membership required.
+
+# AMD HSMP (socket power, DDR bandwidth, clocks)
+KERNEL=="hsmp", TAG+="uaccess"
+
+# IPMI BMC (temperature, voltage, fan, power)
+KERNEL=="ipmi[0-9]*", TAG+="uaccess"
+
+# I2C buses (PMBus VRMs, SPD DIMM thermal)
+# Broad match is intentional: sensor bus numbers are dynamically assigned and
+# vary per board — it is not possible to enumerate specific buses statically.
+KERNEL=="i2c-[0-9]*", TAG+="uaccess"
+
+# Port I/O (Super I/O chips: ITE IT87xx, Nuvoton NCT67xx)
+KERNEL=="port", TAG+="uaccess"
+
+# sinfo_io kernel module (atomic Super I/O register reads)
+KERNEL=="sinfo_io", TAG+="uaccess"
+
+# resctrl (LLC occupancy / MBM) is deliberately excluded: it is a filesystem
+# mount point, not a device node, and requires "mount -t resctrl resctrl
+# /sys/fs/resctrl" with appropriate privileges — udev cannot handle it.


### PR DESCRIPTION
Ship udev rules, tmpfiles.d config, and file capabilities so all sensors work without root for logged-in users.

udev rules (packaging/udev/50-siomon.rules):
- TAG+="uaccess" on /dev/hsmp, /dev/ipmi*, /dev/i2c-*, /dev/port, /dev/sinfo_io — systemd-logind sets POSIX ACLs for the active console user, no group needed

tmpfiles.d (packaging/tmpfiles/siomon.conf):
- RAPL energy counters (/sys/class/powercap/) are 0400 root on many distros — make world-readable at boot via systemd-tmpfiles z directive

File capabilities (post-install hooks):
- setcap cap_perfmon,cap_sys_rawio=ep on /usr/bin/sio
- cap_perfmon: perf_event_open for L3 cache hit rate
- cap_sys_rawio: /dev/port for Super I/O chips

AUR (packaging/aur/):
- PKGBUILD installs udev rules and tmpfiles.d config
- siomon.install runs setcap in post_install; udev and tmpfiles are handled by pre-existing libalpm hooks
- libcap added to depends for setcap availability

Debian/PPA (packaging/launchpad/debian/):
- siomon.udev and siomon.tmpfiles copied from canonical sources during CI build for debhelper auto-install
- postinst runs setcap; udev and tmpfiles are handled by dh_installudev and dh_installtmpfiles via DEBHELPER
- override_dh_fixperms re-applies caps after strip
- libcap2-bin added to Build-Depends and Depends

CI workflows:
- publish-aur.yml copies siomon.install to builder and pushes it to AUR alongside PKGBUILD and .SRCINFO
- publish-ppa.yml copies canonical udev/tmpfiles into debian/ at build time; sed pattern narrowed to not break with added libcap2-bin in Build-Depends