### PR TITLE
Add shell completion scripts

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,27 +38,27 @@ File issues at [github.com/level1techs/siomon/issues](https://github.com/level1t
 
 sio reads directly from Linux kernel interfaces -- no lm-sensors or other userspace daemons required.
 
-| Data | Source |
-|------|--------|
-| CPU identification | CPUID instruction (`raw-cpuid` crate) |
-| CPU topology | `/sys/devices/system/cpu/cpu*/topology/` |
-| CPU frequency | `/sys/devices/system/cpu/cpu*/cpufreq/` |
-| CPU utilization | `/proc/stat` |
-| CPU vulnerabilities | `/sys/devices/system/cpu/vulnerabilities/` |
-| Memory | `/proc/meminfo` + SMBIOS Type 17 |
-| Motherboard/BIOS | `/sys/class/dmi/id/` |
-| Chipset | PCI host bridge at `0000:00:00.0` |
-| UEFI/Secure Boot | `/sys/firmware/efi/` |
-| GPU (NVIDIA) | NVML via `dlopen("libnvidia-ml.so.1")` |
-| GPU (AMD) | `/sys/class/drm/card*/device/` + hwmon |
-| GPU (Intel) | `/sys/class/drm/card*/` + hwmon |
-| Storage | `/sys/class/block/` + `/sys/class/nvme/` |
-| Network | `/sys/class/net/` + `getifaddrs()` |
-| PCI devices | `/sys/bus/pci/devices/` + `pci.ids` (embedded) |
-| Sensors (hwmon) | `/sys/class/hwmon/hwmon*/` |
-| Power (RAPL) | `/sys/class/powercap/intel-rapl:*/` |
-| Disk throughput | `/proc/diskstats` |
-| Network throughput | `/sys/class/net/*/statistics/` |
+| Data                | Source                                         |
+| ------------------- | ---------------------------------------------- |
+| CPU identification  | CPUID instruction (`raw-cpuid` crate)          |
+| CPU topology        | `/sys/devices/system/cpu/cpu*/topology/`       |
+| CPU frequency       | `/sys/devices/system/cpu/cpu*/cpufreq/`        |
+| CPU utilization     | `/proc/stat`                                   |
+| CPU vulnerabilities | `/sys/devices/system/cpu/vulnerabilities/`     |
+| Memory              | `/proc/meminfo` + SMBIOS Type 17               |
+| Motherboard/BIOS    | `/sys/class/dmi/id/`                           |
+| Chipset             | PCI host bridge at `0000:00:00.0`              |
+| UEFI/Secure Boot    | `/sys/firmware/efi/`                           |
+| GPU (NVIDIA)        | NVML via `dlopen("libnvidia-ml.so.1")`         |
+| GPU (AMD)           | `/sys/class/drm/card*/device/` + hwmon         |
+| GPU (Intel)         | `/sys/class/drm/card*/` + hwmon                |
+| Storage             | `/sys/class/block/` + `/sys/class/nvme/`       |
+| Network             | `/sys/class/net/` + `getifaddrs()`             |
+| PCI devices         | `/sys/bus/pci/devices/` + `pci.ids` (embedded) |
+| Sensors (hwmon)     | `/sys/class/hwmon/hwmon*/`                     |
+| Power (RAPL)        | `/sys/class/powercap/intel-rapl:*/`            |
+| Disk throughput     | `/proc/diskstats`                              |
+| Network throughput  | `/sys/class/net/*/statistics/`                 |
 
 ## Project Structure
 
@@ -134,20 +134,21 @@ src/
 
 ## Dependencies
 
-| Crate | Version | Purpose |
-|-------|---------|---------|
-| `raw-cpuid` | 11 | x86 CPUID instruction parsing |
-| `serde` + `serde_json` | 1 | Serialization for JSON output |
-| `toml` | 0.8 | Config file parsing |
-| `clap` | 4 | CLI argument parsing |
-| `ratatui` + `crossterm` | 0.29 / 0.28 | Terminal UI (optional: `tui` feature) |
-| `quick-xml` | 0.37 | XML output (optional: `xml` feature) |
-| `csv` | 1 | CSV sensor logging (optional: `csv` feature) |
-| `pci-ids` | 0.2 | PCI vendor/device name database (compiled in) |
-| `libloading` | 0.8 | dlopen for NVML (optional: `nvidia` feature) |
-| `nix` | 0.29 | Unix syscall wrappers |
-| `libc` | 0.2 | C FFI types (getifaddrs) |
-| `chrono` | 0.4 | Timestamps |
-| `thiserror` | 2 | Error derive macros |
-| `glob` | 0.3 | Sysfs path enumeration |
-| `log` + `env_logger` | 0.4 / 0.11 | Debug logging (`RUST_LOG=debug`) |
+| Crate                   | Version     | Purpose                                       |
+| ----------------------- | ----------- | --------------------------------------------- |
+| `raw-cpuid`             | 11          | x86 CPUID instruction parsing                 |
+| `serde` + `serde_json`  | 1           | Serialization for JSON output                 |
+| `toml`                  | 0.8         | Config file parsing                           |
+| `clap`                  | 4           | CLI argument parsing                          |
+| `clap_complete`         | 4           | Shell completions                             |
+| `ratatui` + `crossterm` | 0.29 / 0.28 | Terminal UI (optional: `tui` feature)         |
+| `quick-xml`             | 0.37        | XML output (optional: `xml` feature)          |
+| `csv`                   | 1           | CSV sensor logging (optional: `csv` feature)  |
+| `pci-ids`               | 0.2         | PCI vendor/device name database (compiled in) |
+| `libloading`            | 0.8         | dlopen for NVML (optional: `nvidia` feature)  |
+| `nix`                   | 0.29        | Unix syscall wrappers                         |
+| `libc`                  | 0.2         | C FFI types (getifaddrs)                      |
+| `chrono`                | 0.4         | Timestamps                                    |
+| `thiserror`             | 2           | Error derive macros                           |
+| `glob`                  | 0.3         | Sysfs path enumeration                        |
+| `log` + `env_logger`    | 0.4 / 0.11  | Debug logging (`RUST_LOG=debug`)              |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,6 +1638,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "siomon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,14 @@ csv = ["dep:csv"]
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 raw-cpuid = "11"
 
+[workspace]
+members = [".", "xtask"]
+
+[workspace.dependencies]
+clap = { version = "4", features = ["derive", "env", "string"] }
+clap_complete = "4"
+
+
 [dependencies]
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -44,7 +52,7 @@ ratatui = { version = "0.29", optional = true }
 crossterm = { version = "0.28", optional = true }
 
 # CLI
-clap = { version = "4", features = ["derive", "env", "string"] }
+clap.workspace = true
 
 # Unix / Linux syscalls
 nix = { version = "0.29", features = ["fs", "ioctl", "mman", "process"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+siomon = { path = ".." }
+clap.workspace = true
+clap_complete.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,35 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+struct Cli {
+    #[command(subcommand)]
+    pub(crate) command: Cmd,
+}
+#[derive(Subcommand)]
+enum Cmd {
+    ShellCompletion(ShellCompletion),
+}
+
+#[derive(Parser)]
+struct ShellCompletion {
+    #[clap(value_enum)]
+    shell: clap_complete::Shell,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    let mut cmd = <siomon::cli::Cli as clap::CommandFactory>::command();
+    match cli.command {
+        Cmd::ShellCompletion(shell_completion) => {
+            let bin_name = cmd.get_name().to_string();
+
+            clap_complete::generate(
+                shell_completion.shell,
+                &mut cmd,
+                bin_name,
+                &mut std::io::stdout(),
+            );
+        }
+    }
+}


### PR DESCRIPTION
This is done via the amazing [cargo xtask](https://github.com/matklad/cargo-xtask) paradigm. 
Another possible solution would be to add "shell completions" as an option to `Commands`. As shell completions are only useful when packaging an application I prefer the xtask approach.

As I only use Nix I will add shell completions to its package, but cannot provide integrations with other packaging formats.