### PR TITLE
Add least-privilege permissions to CI and AUR workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -29,6 +29,9 @@ on:
       PKG_GIT_EMAIL:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Build and push to AUR


### PR DESCRIPTION
Fixes 7 CodeQL alerts for missing permissions declarations. Both workflows only need contents:read — CI for checkout+build, AUR for checkout (push uses SSH secrets, not GITHUB_TOKEN).