### PR TITLE
Bump MSRV to 1.88, upgrade ratatui 0.30 and crossterm 0.29

### DIFF
--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -218,8 +218,8 @@ jobs:
             # Determine series-specific Rust packages
             case "$series" in
               noble)
-                RUST_PKGS="cargo-1.85, rustc-1.85"
-                CARGO_BIN="cargo-1.85"
+                RUST_PKGS="cargo-1.88, rustc-1.88"
+                CARGO_BIN="cargo-1.88"
                 ;;
               *)
                 RUST_PKGS="cargo, rustc"
@@ -234,7 +234,7 @@ jobs:
 
             # Copy debian/ from packaging templates. These are not used as-is:
             # changelog is overwritten below, and control/rules are sed-modified
-            # per series (e.g. Noble uses versioned cargo-1.85/rustc-1.85).
+            # per series (e.g. Noble uses versioned cargo-1.88/rustc-1.88).
             cp -r "$GITHUB_WORKSPACE/packaging/launchpad/debian" "$BUILD_DIR/debian"
 
             # Canonical udev/tmpfiles live in packaging/ — copy for debhelper
@@ -253,7 +253,7 @@ jobs:
             } > "$BUILD_DIR/debian/changelog"
 
             # Adjust Build-Depends for series (replace cargo/rustc, keep other deps)
-            sed -i "s/cargo, rustc (>= 1.85)/${RUST_PKGS}/" \
+            sed -i "s/cargo, rustc (>= 1.88)/${RUST_PKGS}/" \
               "$BUILD_DIR/debian/control"
 
             # Adjust cargo binary name in rules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-- Rust 1.85+ (edition 2024)
+- Rust 1.88+ (edition 2024)
 - Linux (kernel 4.x+ for full sysfs support; 5.x+ recommended)
 - Standard build tools (`gcc` or `cc` for libc linking)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -54,15 +54,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -73,7 +73,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -84,7 +84,22 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -92,6 +107,27 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -130,10 +166,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
+name = "bytemuck"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "castaway"
@@ -155,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -201,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -211,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -232,33 +268,33 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -266,6 +302,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -285,12 +330,14 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.0",
  "crossterm_winapi",
+ "derive_more",
+ "document-features",
  "mio",
  "parking_lot",
  "rustix",
@@ -319,6 +366,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -351,28 +408,33 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
@@ -381,6 +443,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -395,6 +479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,9 +495,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -412,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -436,7 +529,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -444,6 +567,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -456,6 +591,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "generic-array"
@@ -479,6 +620,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,9 +656,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -500,12 +664,23 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -541,6 +716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,12 +729,14 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -577,15 +760,15 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling",
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -597,7 +780,7 @@ dependencies = [
  "aes",
  "bitflags 1.3.2",
  "cbc",
- "getrandom",
+ "getrandom 0.2.17",
  "hmac",
  "ipmi-rs-core",
  "log",
@@ -628,18 +811,18 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -662,24 +845,53 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.182"
+name = "kasuari"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -692,10 +904,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -714,11 +941,21 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
 ]
 
 [[package]]
@@ -734,6 +971,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,14 +993,14 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -772,6 +1024,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -792,9 +1045,20 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-traits"
@@ -806,16 +1070,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "num_threads"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"
@@ -841,12 +1123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pci-ids"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,11 +1136,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -889,6 +1209,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,9 +1238,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -925,6 +1258,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -956,6 +1299,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,28 +1337,92 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags 2.11.0",
- "cassowary",
  "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
  "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
+ "line-clipping",
+ "ratatui-core",
  "strum",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1054,16 +1473,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1083,6 +1511,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1111,7 +1545,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1141,6 +1575,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1205,7 +1650,7 @@ dependencies = [
  "raw-cpuid",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
 ]
 
@@ -1235,24 +1680,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1260,6 +1704,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1273,12 +1728,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1289,18 +1827,20 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -1309,15 +1849,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1371,6 +1911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,32 +1924,32 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.0"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -1412,10 +1958,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wasi"
@@ -1424,10 +1991,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.114"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1438,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1448,24 +2033,130 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -1511,7 +2202,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1522,7 +2213,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1551,15 +2242,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1568,76 +2250,100 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1651,22 +2357,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "siomon"
 version = "0.2.3"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 description = "Linux hardware information and sensor monitoring tool"
 license = "MIT"
 keywords = ["hardware", "sensors", "hwmon", "system-info", "monitoring"]
@@ -48,8 +48,8 @@ quick-xml = { version = "0.37", features = ["serialize"], optional = true }
 csv = { version = "1", optional = true }
 
 # TUI
-ratatui = { version = "0.29", optional = true }
-crossterm = { version = "0.28", optional = true }
+ratatui = { version = "0.30", optional = true }
+crossterm = { version = "0.29", optional = true }
 
 # CLI
 clap.workspace = true

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -572,7 +572,7 @@ build fails:
 2. Common issues:
    - Missing build dependencies in `packaging/launchpad/debian/control`.
    - Rust version too old in the target series (the workflow handles noble
-     specially with `cargo-1.85`/`rustc-1.85`).
+     specially with `cargo-1.88`/`rustc-1.88`).
    - Vendored dependencies are incomplete — re-run the workflow (repack
      increments automatically).
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Fields requiring elevation show `[requires root]` or are omitted.
 
 ### Prerequisites
 
-- Rust 1.85+ (edition 2024)
+- Rust 1.88+ (edition 2024)
 - Linux (kernel 4.x+ for full sysfs support; 5.x+ recommended)
 - Standard build tools (`gcc` or `cc` for libc linking)
 

--- a/packaging/launchpad/README.md
+++ b/packaging/launchpad/README.md
@@ -33,7 +33,7 @@ The GitHub Actions workflow (`.github/workflows/publish-ppa.yml`) runs on
 4. Creates an orig tarball (`siomon_{version}+ds{repack}.orig.tar.gz`).
 5. For each Ubuntu series, copies the `debian/` templates, writes a
    series-specific changelog, adjusts build dependencies (Noble uses
-   `cargo-1.85`/`rustc-1.85`), and runs `debuild -S`.
+   `cargo-1.88`/`rustc-1.88`), and runs `debuild -S`.
 6. Signs all `.changes` files with GPG via `debsign`.
 7. **Ensures the GPG key is on `keyserver.ubuntu.com`** — checks
    retrievability; if missing, publishes the key and dispatches the
@@ -64,7 +64,7 @@ Example progression:
 
 | Series | Rust Packages | Cargo Binary |
 |--------|--------------|--------------|
-| Noble (24.04) | `cargo-1.85`, `rustc-1.85` | `cargo-1.85` |
+| Noble (24.04) | `cargo-1.88`, `rustc-1.88` | `cargo-1.88` |
 | Others (e.g., Questing) | `cargo`, `rustc` | `cargo` |
 
 The workflow uses `sed` to adjust `debian/control` (Build-Depends) and

--- a/packaging/launchpad/debian/control
+++ b/packaging/launchpad/debian/control
@@ -6,7 +6,7 @@ Maintainer: Level1Techs Package Team <level1techspackageteam@gmail.com>
 #   cap_perfmon + cap_sys_rawio on the sio binary so sensors work without root.
 #   Also needed at build time because dh_fixperms strips capabilities and we
 #   must re-apply them before the .deb is assembled.
-Build-Depends: debhelper-compat (= 13), cargo, rustc (>= 1.85), libcap2-bin
+Build-Depends: debhelper-compat (= 13), cargo, rustc (>= 1.88), libcap2-bin
 Standards-Version: 4.6.2
 Homepage: https://github.com/level1techs/siomon
 Vcs-Git: https://github.com/level1techs/siomon.git

--- a/src/collectors/cpu.rs
+++ b/src/collectors/cpu.rs
@@ -622,10 +622,10 @@ fn parse_numa_meminfo(path: &Path) -> Option<u64> {
         if line.contains("MemTotal") {
             // Format: "Node X MemTotal:    12345 kB"
             let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() >= 4 {
-                if let Ok(kb) = parts[3].parse::<u64>() {
-                    return Some(kb * 1024);
-                }
+            if parts.len() >= 4
+                && let Ok(kb) = parts[3].parse::<u64>()
+            {
+                return Some(kb * 1024);
             }
         }
     }

--- a/src/collectors/gpu.rs
+++ b/src/collectors/gpu.rs
@@ -300,18 +300,17 @@ fn parse_connector(s: &str) -> Option<(String, u32)> {
     ];
 
     for prefix in &known_types {
-        if let Some(rest) = s.strip_prefix(prefix) {
-            if let Some(idx_str) = rest.strip_prefix('-') {
-                if let Ok(idx) = idx_str.parse::<u32>() {
-                    // Normalize HDMI-A/HDMI-B to HDMI
-                    let display_type = if prefix.starts_with("HDMI") {
-                        "HDMI".to_string()
-                    } else {
-                        prefix.to_string()
-                    };
-                    return Some((display_type, idx));
-                }
-            }
+        if let Some(rest) = s.strip_prefix(prefix)
+            && let Some(idx_str) = rest.strip_prefix('-')
+            && let Ok(idx) = idx_str.parse::<u32>()
+        {
+            // Normalize HDMI-A/HDMI-B to HDMI
+            let display_type = if prefix.starts_with("HDMI") {
+                "HDMI".to_string()
+            } else {
+                prefix.to_string()
+            };
+            return Some((display_type, idx));
         }
     }
     None
@@ -416,15 +415,14 @@ impl crate::collectors::Collector for GpuCollector {
 fn normalize_bus_addr(addr: &str) -> String {
     let s = addr.trim().to_lowercase();
     // If domain is 8 digits (e.g. "00000000:11:00.0"), truncate to 4
-    if s.len() > 12 {
-        if let Some(first_colon) = s.find(':') {
-            if first_colon > 4 {
-                let domain = &s[..first_colon];
-                // Take last 4 chars of domain
-                let short_domain = &domain[domain.len().saturating_sub(4)..];
-                return format!("{}{}", short_domain, &s[first_colon..]);
-            }
-        }
+    if s.len() > 12
+        && let Some(first_colon) = s.find(':')
+        && first_colon > 4
+    {
+        let domain = &s[..first_colon];
+        // Take last 4 chars of domain
+        let short_domain = &domain[domain.len().saturating_sub(4)..];
+        return format!("{}{}", short_domain, &s[first_colon..]);
     }
     s
 }
@@ -481,10 +479,9 @@ fn read_amd_max_sclk(path: &Path) -> Option<u32> {
                 .strip_suffix("Mhz")
                 .or_else(|| part.strip_suffix("MHz"))
                 .or_else(|| part.strip_suffix("mhz"))
+                && let Ok(mhz) = mhz_str.parse::<u32>()
             {
-                if let Ok(mhz) = mhz_str.parse::<u32>() {
-                    max_mhz = Some(max_mhz.map_or(mhz, |prev: u32| prev.max(mhz)));
-                }
+                max_mhz = Some(max_mhz.map_or(mhz, |prev: u32| prev.max(mhz)));
             }
         }
     }

--- a/src/collectors/memory.rs
+++ b/src/collectors/memory.rs
@@ -19,14 +19,14 @@ pub fn collect(direct_io: bool, board: Option<&'static BoardTemplate>) -> Memory
     };
 
     // Enrich DIMMs with SPD EEPROM data on supported boards (requires --direct-io).
-    if let Some(b) = direct_io.then_some(board).flatten() {
-        if let Some(ddr5_config) = b.ddr5_bus_config {
-            enrich_dimms_with_spd(
-                &mut dimms,
-                ddr5_config,
-                b.requirements.get(crate::db::boards::FEAT_DDR5),
-            );
-        }
+    if let Some(b) = direct_io.then_some(board).flatten()
+        && let Some(ddr5_config) = b.ddr5_bus_config
+    {
+        enrich_dimms_with_spd(
+            &mut dimms,
+            ddr5_config,
+            b.requirements.get(crate::db::boards::FEAT_DDR5),
+        );
     }
 
     MemoryInfo {
@@ -169,87 +169,86 @@ fn parse_dmi_type17(text: &str) -> Vec<DimmInfo> {
         let trimmed = line.trim();
 
         if trimmed.starts_with("Memory Device") {
-            if let Some(builder) = current.take() {
-                if let Some(dimm) = builder.build() {
-                    dimms.push(dimm);
-                }
+            if let Some(builder) = current.take()
+                && let Some(dimm) = builder.build()
+            {
+                dimms.push(dimm);
             }
             current = Some(DimmBuilder::default());
         }
 
-        if let Some(ref mut b) = current {
-            if let Some((key, val)) = trimmed.split_once(':') {
-                let key = key.trim();
-                let val = val.trim();
-                if val == "Not Provided"
-                    || val == "Unknown"
-                    || val == "No Module Installed"
-                    || val == "Not Specified"
-                {
-                    continue;
+        if let Some(ref mut b) = current
+            && let Some((key, val)) = trimmed.split_once(':')
+        {
+            let key = key.trim();
+            let val = val.trim();
+            if val == "Not Provided"
+                || val == "Unknown"
+                || val == "No Module Installed"
+                || val == "Not Specified"
+            {
+                continue;
+            }
+            match key {
+                "Locator" => b.locator = Some(val.to_string()),
+                "Bank Locator" => b.bank_locator = Some(val.to_string()),
+                "Manufacturer" => b.manufacturer = filter_placeholder(val),
+                "Part Number" => b.part_number = filter_placeholder(val),
+                "Serial Number" => b.serial_number = filter_placeholder(val),
+                "Size" => {
+                    if let Some(mb_str) = val.strip_suffix(" MB") {
+                        b.size_bytes = mb_str.trim().parse::<u64>().ok().map(|v| v * 1024 * 1024);
+                    } else if let Some(gb_str) = val.strip_suffix(" GB") {
+                        b.size_bytes = gb_str
+                            .trim()
+                            .parse::<u64>()
+                            .ok()
+                            .map(|v| v * 1024 * 1024 * 1024);
+                    }
                 }
-                match key {
-                    "Locator" => b.locator = Some(val.to_string()),
-                    "Bank Locator" => b.bank_locator = Some(val.to_string()),
-                    "Manufacturer" => b.manufacturer = filter_placeholder(val),
-                    "Part Number" => b.part_number = filter_placeholder(val),
-                    "Serial Number" => b.serial_number = filter_placeholder(val),
-                    "Size" => {
-                        if let Some(mb_str) = val.strip_suffix(" MB") {
-                            b.size_bytes =
-                                mb_str.trim().parse::<u64>().ok().map(|v| v * 1024 * 1024);
-                        } else if let Some(gb_str) = val.strip_suffix(" GB") {
-                            b.size_bytes = gb_str
-                                .trim()
-                                .parse::<u64>()
-                                .ok()
-                                .map(|v| v * 1024 * 1024 * 1024);
-                        }
-                    }
-                    "Type" => b.memory_type = Some(parse_memory_type(val)),
-                    "Form Factor" => b.form_factor = Some(val.to_string()),
-                    "Type Detail" => b.type_detail = Some(val.to_string()),
-                    "Speed" => {
-                        b.max_speed_mts = val
-                            .split_whitespace()
-                            .next()
-                            .and_then(|s| s.parse::<u32>().ok());
-                    }
-                    "Configured Memory Speed" | "Configured Clock Speed" => {
-                        b.configured_speed_mts = val
-                            .split_whitespace()
-                            .next()
-                            .and_then(|s| s.parse::<u32>().ok());
-                    }
-                    "Configured Voltage" => {
-                        if let Some(v_str) = val.strip_suffix(" V") {
-                            b.configured_voltage_mv = v_str
-                                .trim()
-                                .parse::<f64>()
-                                .ok()
-                                .map(|v| (v * 1000.0) as u32);
-                        }
-                    }
-                    "Data Width" => {
-                        b.data_width_bits = val
-                            .strip_suffix(" bits")
-                            .and_then(|s| s.trim().parse::<u16>().ok());
-                    }
-                    "Total Width" => {
-                        b.total_width_bits = val
-                            .strip_suffix(" bits")
-                            .and_then(|s| s.trim().parse::<u16>().ok());
-                    }
-                    "Rank" => b.rank = val.parse::<u8>().ok(),
-                    _ => {}
+                "Type" => b.memory_type = Some(parse_memory_type(val)),
+                "Form Factor" => b.form_factor = Some(val.to_string()),
+                "Type Detail" => b.type_detail = Some(val.to_string()),
+                "Speed" => {
+                    b.max_speed_mts = val
+                        .split_whitespace()
+                        .next()
+                        .and_then(|s| s.parse::<u32>().ok());
                 }
+                "Configured Memory Speed" | "Configured Clock Speed" => {
+                    b.configured_speed_mts = val
+                        .split_whitespace()
+                        .next()
+                        .and_then(|s| s.parse::<u32>().ok());
+                }
+                "Configured Voltage" => {
+                    if let Some(v_str) = val.strip_suffix(" V") {
+                        b.configured_voltage_mv = v_str
+                            .trim()
+                            .parse::<f64>()
+                            .ok()
+                            .map(|v| (v * 1000.0) as u32);
+                    }
+                }
+                "Data Width" => {
+                    b.data_width_bits = val
+                        .strip_suffix(" bits")
+                        .and_then(|s| s.trim().parse::<u16>().ok());
+                }
+                "Total Width" => {
+                    b.total_width_bits = val
+                        .strip_suffix(" bits")
+                        .and_then(|s| s.trim().parse::<u16>().ok());
+                }
+                "Rank" => b.rank = val.parse::<u8>().ok(),
+                _ => {}
             }
         }
     }
-    if let Some(builder) = current {
-        if let Some(dimm) = builder.build() {
-            dimms.push(dimm);
-        }
+    if let Some(builder) = current
+        && let Some(dimm) = builder.build()
+    {
+        dimms.push(dimm);
     }
     dimms
 }

--- a/src/collectors/motherboard.rs
+++ b/src/collectors/motherboard.rs
@@ -90,11 +90,11 @@ fn supplement_from_smbios(info: &mut MotherboardInfo, data: &smbios::SmbiosData)
         if info.bios.date.is_none() {
             info.bios.date = bios.release_date.clone();
         }
-        if info.bios.release.is_none() {
-            if let (Some(major), Some(minor)) = (bios.major_release, bios.minor_release) {
-                // Match the sysfs format: "major.minor"
-                info.bios.release = Some(format!("{major}.{minor}"));
-            }
+        if info.bios.release.is_none()
+            && let (Some(major), Some(minor)) = (bios.major_release, bios.minor_release)
+        {
+            // Match the sysfs format: "major.minor"
+            info.bios.release = Some(format!("{major}.{minor}"));
         }
     }
 }

--- a/src/collectors/storage.rs
+++ b/src/collectors/storage.rs
@@ -214,10 +214,10 @@ fn detect_interface(block_path: &Path) -> StorageInterface {
 
     // Check for virtio
     let driver = sysfs::read_link_basename(&dev_path.join("driver"));
-    if let Some(ref d) = driver {
-        if d.contains("virtio") {
-            return StorageInterface::VirtIO;
-        }
+    if let Some(ref d) = driver
+        && d.contains("virtio")
+    {
+        return StorageInterface::VirtIO;
     }
 
     // Check for MMC

--- a/src/output/tui/dashboard.rs
+++ b/src/output/tui/dashboard.rs
@@ -504,10 +504,10 @@ fn build_panels<'a>(
         panels.push(p);
     }
     // Per-core panels only in 3-col — too many rows for narrow layouts
-    if three_col {
-        if let Some(p) = build_cpu_freq_panel(snapshot, history, spark_width, max_entries, theme) {
-            panels.push(p);
-        }
+    if three_col
+        && let Some(p) = build_cpu_freq_panel(snapshot, history, spark_width, max_entries, theme)
+    {
+        panels.push(p);
     }
     // Voltage and GPU in all layout modes
     if let Some(p) = build_voltage_panel(snapshot, history, spark_width, max_entries, theme) {

--- a/src/output/tui/mod.rs
+++ b/src/output/tui/mod.rs
@@ -497,10 +497,10 @@ fn run_loop(
                                 KeyCode::Up | KeyCode::Char('k') if view_mode == ViewMode::Tree => {
                                     if cursor > 0 {
                                         cursor -= 1;
-                                        if let Some(&row_idx) = group_indices.get(cursor) {
-                                            if row_idx < scroll_offset {
-                                                scroll_offset = row_idx;
-                                            }
+                                        if let Some(&row_idx) = group_indices.get(cursor)
+                                            && row_idx < scroll_offset
+                                        {
+                                            scroll_offset = row_idx;
                                         }
                                     }
                                 }
@@ -540,10 +540,10 @@ fn run_loop(
                                 KeyCode::PageUp if view_mode == ViewMode::Tree => {
                                     scroll_offset = scroll_offset.saturating_sub(20);
                                     while cursor > 0 {
-                                        if let Some(&ri) = group_indices.get(cursor) {
-                                            if ri >= scroll_offset {
-                                                break;
-                                            }
+                                        if let Some(&ri) = group_indices.get(cursor)
+                                            && ri >= scroll_offset
+                                        {
+                                            break;
                                         }
                                         cursor -= 1;
                                     }
@@ -551,10 +551,10 @@ fn run_loop(
                                 KeyCode::PageDown if view_mode == ViewMode::Tree => {
                                     scroll_offset = scroll_offset.saturating_add(20);
                                     while cursor + 1 < group_indices.len() {
-                                        if let Some(&ri) = group_indices.get(cursor) {
-                                            if ri >= scroll_offset {
-                                                break;
-                                            }
+                                        if let Some(&ri) = group_indices.get(cursor)
+                                            && ri >= scroll_offset
+                                        {
+                                            break;
                                         }
                                         cursor += 1;
                                     }

--- a/src/output/tui/theme.rs
+++ b/src/output/tui/theme.rs
@@ -16,10 +16,10 @@ pub fn detect_color_level() -> ColorLevel {
     if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
         return ColorLevel::None;
     }
-    if let Ok(ct) = std::env::var("COLORTERM") {
-        if ct == "truecolor" || ct == "24bit" {
-            return ColorLevel::TrueColor;
-        }
+    if let Ok(ct) = std::env::var("COLORTERM")
+        && (ct == "truecolor" || ct == "24bit")
+    {
+        return ColorLevel::TrueColor;
     }
     if let Ok(term) = std::env::var("TERM") {
         if term == "dumb" {

--- a/src/parsers/smbios.rs
+++ b/src/parsers/smbios.rs
@@ -520,11 +520,11 @@ fn decode_memory_size(raw_size: u16, data: &[u8], header_len: usize) -> u64 {
 
     if raw_size == 0x7FFF {
         // Extended size at offset 0x1C (u32, megabytes, bit 31 reserved).
-        if header_len > 0x1F {
-            if let Some(ext) = read_u32_le(data, 0x1C) {
-                let mb = (ext & 0x7FFF_FFFF) as u64;
-                return mb * 1024 * 1024;
-            }
+        if header_len > 0x1F
+            && let Some(ext) = read_u32_le(data, 0x1C)
+        {
+            let mb = (ext & 0x7FFF_FFFF) as u64;
+            return mb * 1024 * 1024;
         }
         return 0;
     }

--- a/src/platform/tegra.rs
+++ b/src/platform/tegra.rs
@@ -109,19 +109,19 @@ impl crate::sensors::SensorSource for DevfreqGpuSource {
             }
 
             // GPU load — devfreq reports 0-1000 (promille), divide by 10 for percent
-            if let Some(ref load_path) = gpu.load_path {
-                if let Some(raw) = sysfs::read_u64_optional(load_path) {
-                    let pct = raw as f64 / 10.0;
-                    readings.push((
-                        sid("tegra-gpu", chip, "load"),
-                        SensorReading::new(
-                            format!("{chip} Load"),
-                            pct,
-                            SensorUnit::Percent,
-                            SensorCategory::Utilization,
-                        ),
-                    ));
-                }
+            if let Some(ref load_path) = gpu.load_path
+                && let Some(raw) = sysfs::read_u64_optional(load_path)
+            {
+                let pct = raw as f64 / 10.0;
+                readings.push((
+                    sid("tegra-gpu", chip, "load"),
+                    SensorReading::new(
+                        format!("{chip} Load"),
+                        pct,
+                        SensorUnit::Percent,
+                        SensorCategory::Utilization,
+                    ),
+                ));
             }
 
             // Max frequency (static, cached from discovery)

--- a/src/sensors/aer.rs
+++ b/src/sensors/aer.rs
@@ -132,19 +132,19 @@ fn resolve_pci_label(dev_dir: &std::path::Path, bdf: &str) -> String {
     let vid = sysfs::read_u64_optional(&dev_dir.join("vendor")).map(|v| v as u16);
     let did = sysfs::read_u64_optional(&dev_dir.join("device")).map(|v| v as u16);
 
-    if let (Some(vid), Some(did)) = (vid, did) {
-        if let Some(dev) = pci_ids::Device::from_vid_pid(vid, did) {
-            let name = dev.name();
-            let short = if name.len() > 40 {
-                match name.char_indices().nth(40) {
-                    Some((idx, _)) => &name[..idx],
-                    None => name,
-                }
-            } else {
-                name
-            };
-            return format!("{short} [{bdf}]");
-        }
+    if let (Some(vid), Some(did)) = (vid, did)
+        && let Some(dev) = pci_ids::Device::from_vid_pid(vid, did)
+    {
+        let name = dev.name();
+        let short = if name.len() > 40 {
+            match name.char_indices().nth(40) {
+                Some((idx, _)) => &name[..idx],
+                None => name,
+            }
+        } else {
+            name
+        };
+        return format!("{short} [{bdf}]");
     }
     bdf.to_string()
 }

--- a/src/sensors/alerts.rs
+++ b/src/sensors/alerts.rs
@@ -54,10 +54,10 @@ impl AlertEngine {
 
                 // Check cooldown
                 let key = format!("{}:{}", rule.sensor_pattern, id_str);
-                if let Some(last) = self.last_triggered.get(&key) {
-                    if now.duration_since(*last) < rule.cooldown {
-                        continue;
-                    }
+                if let Some(last) = self.last_triggered.get(&key)
+                    && now.duration_since(*last) < rule.cooldown
+                {
+                    continue;
                 }
 
                 self.last_triggered.insert(key, now);

--- a/src/sensors/gpu_sensors.rs
+++ b/src/sensors/gpu_sensors.rs
@@ -315,32 +315,32 @@ fn poll_amd(gpus: &[AmdGpu], readings: &mut Vec<(SensorId, SensorReading)>) {
             ));
         }
 
-        if let Some(ref path) = gpu.busy_path {
-            if let Some(pct) = sysfs::read_u64_optional(path) {
-                let id = sid("amdgpu", &chip, "gpu_util");
-                let label = format!("{} GPU Utilization", gpu.name);
-                readings.push((
-                    id,
-                    SensorReading::new(
-                        label,
-                        pct as f64,
-                        SensorUnit::Percent,
-                        SensorCategory::Utilization,
-                    ),
-                ));
-            }
+        if let Some(ref path) = gpu.busy_path
+            && let Some(pct) = sysfs::read_u64_optional(path)
+        {
+            let id = sid("amdgpu", &chip, "gpu_util");
+            let label = format!("{} GPU Utilization", gpu.name);
+            readings.push((
+                id,
+                SensorReading::new(
+                    label,
+                    pct as f64,
+                    SensorUnit::Percent,
+                    SensorCategory::Utilization,
+                ),
+            ));
         }
 
-        if let Some(ref path) = gpu.vram_used_path {
-            if let Some(used) = sysfs::read_u64_optional(path) {
-                let id = sid("amdgpu", &chip, "vram_used");
-                let label = format!("{} VRAM Used", gpu.name);
-                let mb = used as f64 / (1024.0 * 1024.0);
-                readings.push((
-                    id,
-                    SensorReading::new(label, mb, SensorUnit::Megabytes, SensorCategory::Memory),
-                ));
-            }
+        if let Some(ref path) = gpu.vram_used_path
+            && let Some(used) = sysfs::read_u64_optional(path)
+        {
+            let id = sid("amdgpu", &chip, "vram_used");
+            let label = format!("{} VRAM Used", gpu.name);
+            let mb = used as f64 / (1024.0 * 1024.0);
+            readings.push((
+                id,
+                SensorReading::new(label, mb, SensorUnit::Megabytes, SensorCategory::Memory),
+            ));
         }
     }
 }

--- a/src/sensors/hwmon.rs
+++ b/src/sensors/hwmon.rs
@@ -153,10 +153,10 @@ impl HwmonSource {
 
             // Apply voltage scaling multipliers from board template
             for entry in &mut entries {
-                if entry.category == SensorCategory::Voltage {
-                    if let Some(&mult) = effective_scaling.get(&entry.id.to_string()) {
-                        entry.multiplier = mult;
-                    }
+                if entry.category == SensorCategory::Voltage
+                    && let Some(&mult) = effective_scaling.get(&entry.id.to_string())
+                {
+                    entry.multiplier = mult;
                 }
             }
 

--- a/src/sensors/i2c/pmbus.rs
+++ b/src/sensors/i2c/pmbus.rs
@@ -175,10 +175,10 @@ impl PmbusSource {
             };
 
             // Select PMBus page if this device uses multi-page
-            if let Some(page) = dev.page {
-                if smbus.write_byte_data(PMBUS_PAGE, page).is_err() {
-                    continue;
-                }
+            if let Some(page) = dev.page
+                && smbus.write_byte_data(PMBUS_PAGE, page).is_err()
+            {
+                continue;
             }
 
             for reg in REGISTERS {
@@ -374,12 +374,11 @@ fn probe_pmbus_with_pages(bus: u32, addr: u16, vrm_index: &mut u32) -> Vec<Pmbus
     }
 
     // Fix up labels: if we found multiple pages, relabel the first one
-    if results.len() > 1 {
-        if let Some(first) = results.first_mut() {
-            first.label_prefix =
-                format!("VRM {} page 0 (bus {} addr {:#04x})", *vrm_index, bus, addr);
-            first.id_prefix = format!("vrm{}_p0", *vrm_index);
-        }
+    if results.len() > 1
+        && let Some(first) = results.first_mut()
+    {
+        first.label_prefix = format!("VRM {} page 0 (bus {} addr {:#04x})", *vrm_index, bus, addr);
+        first.id_prefix = format!("vrm{}_p0", *vrm_index);
     }
 
     // Reset page to 0 when done

--- a/src/sensors/poller.rs
+++ b/src/sensors/poller.rs
@@ -317,10 +317,10 @@ fn discover_all_sources(
         result.extend(join_or_log(h_hsmp.join(), "hsmp"));
         result.extend(join_or_log(h_ipmi.join(), "ipmi"));
 
-        if let Some(h) = h_direct_io {
-            if let Some(dio) = join_or_log(h.join(), "direct-io") {
-                result.extend(dio);
-            }
+        if let Some(h) = h_direct_io
+            && let Some(dio) = join_or_log(h.join(), "direct-io")
+        {
+            result.extend(dio);
         }
 
         result

--- a/src/sensors/superio/nct67xx.rs
+++ b/src/sensors/superio/nct67xx.rs
@@ -109,13 +109,13 @@ impl Nct67xxSource {
     pub fn new(chip: SuperIoChip, label_overrides: &HashMap<String, String>) -> Self {
         let board_name = crate::db::sensor_labels::read_board_name();
         let hwm_access = HwmAccess::open(chip.hwm_base);
-        if let Some(ref access) = hwm_access {
-            if access.is_atomic() {
-                log::info!(
-                    "NCT67xx: using sinfo_io (atomic) for HWM base 0x{:04X}",
-                    chip.hwm_base
-                );
-            }
+        if let Some(ref access) = hwm_access
+            && access.is_atomic()
+        {
+            log::info!(
+                "NCT67xx: using sinfo_io (atomic) for HWM base 0x{:04X}",
+                chip.hwm_base
+            );
         }
         Self {
             chip,


### PR DESCRIPTION
Resolves two Dependabot security alerts:
- time 0.3.45 → 0.3.47 (stack exhaustion DoS via RFC 2822)
- lru 0.12.5 → 0.16.3 (Stacked Borrows soundness in IterMut)

Collapse 28 nested if/if-let blocks into let-chains, which are stable since Rust 1.87 and now flagged by clippy.