### PR TITLE
Allow for building on musl libc systems

### DIFF
--- a/src/platform/nvme_ioctl.rs
+++ b/src/platform/nvme_ioctl.rs
@@ -7,17 +7,6 @@ use std::fs::OpenOptions;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 
-// NVME_IOCTL_ADMIN_CMD = 0xC0484E41
-const NVME_IOCTL_ADMIN_CMD: libc::c_ulong = 0xC0484E41;
-
-// NVMe admin command opcode for Get Log Page
-const NVME_ADMIN_GET_LOG_PAGE: u8 = 0x02;
-
-// SMART/Health log page identifier
-const NVME_LOG_SMART: u32 = 0x02;
-
-// Size of the SMART log in bytes
-const SMART_LOG_SIZE: u32 = 512;
 
 /// NVMe Admin Command structure passed to the ioctl.
 #[repr(C)]
@@ -68,6 +57,17 @@ pub struct NvmeSmartLog {
     pub temp_sensor: [u16; 8],
     pub rsvd_tail: [u8; 296],
 }
+
+const NVME_IOCTL_ADMIN_CMD: libc::Ioctl = libc::_IOWR::<NvmeAdminCmd>(b'N' as u32, 0x41);
+
+// NVMe admin command opcode for Get Log Page
+const NVME_ADMIN_GET_LOG_PAGE: u8 = 0x02;
+
+// SMART/Health log page identifier
+const NVME_LOG_SMART: u32 = 0x02;
+
+// Size of the SMART log in bytes
+const SMART_LOG_SIZE: u32 = 512;
 
 /// Read the NVMe SMART/Health log from a controller device (e.g. `/dev/nvme0`).
 ///

--- a/src/platform/nvme_ioctl.rs
+++ b/src/platform/nvme_ioctl.rs
@@ -7,7 +7,6 @@ use std::fs::OpenOptions;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 
-
 /// NVMe Admin Command structure passed to the ioctl.
 #[repr(C)]
 #[derive(Default)]

--- a/src/platform/sata_ioctl.rs
+++ b/src/platform/sata_ioctl.rs
@@ -9,7 +9,7 @@ use std::os::unix::io::AsRawFd;
 use std::path::Path;
 
 // SG_IO ioctl request number
-const SG_IO: libc::c_ulong = 0x2285;
+const SG_IO: libc::Ioctl = 0x2285;
 
 // SG_IO data transfer direction: from device to host
 const SG_DXFER_FROM_DEV: i32 = -3;

--- a/src/platform/sinfo_io.rs
+++ b/src/platform/sinfo_io.rs
@@ -17,27 +17,11 @@ use super::port_io::PortIo;
 
 // ── IOCTL definitions (mirrors kmod/sinfo_io/sinfo_io.h) ───────────────
 
-const SINFO_IO_MAGIC: u8 = b'S';
 const SINFO_IO_BATCH_MAX: usize = 32;
 
-// _IOW('S', 0x01, sinfo_io_setup)  = direction=1 (write), size=4, type='S', nr=1
-// _IOWR('S', 0x02, sinfo_io_reg)   = direction=3 (rw),    size=4, type='S', nr=2
-// _IOWR('S', 0x03, sinfo_io_batch) = direction=3 (rw),    size=100, type='S', nr=3
-//
-// Linux ioctl encoding: direction(2) << 30 | size(14) << 16 | type(8) << 8 | nr(8)
-const fn iow<T>(nr: u8) -> libc::c_ulong {
-    let size = std::mem::size_of::<T>() as libc::c_ulong;
-    (1 << 30) | (size << 16) | ((SINFO_IO_MAGIC as libc::c_ulong) << 8) | nr as libc::c_ulong
-}
-
-const fn iowr<T>(nr: u8) -> libc::c_ulong {
-    let size = std::mem::size_of::<T>() as libc::c_ulong;
-    (3 << 30) | (size << 16) | ((SINFO_IO_MAGIC as libc::c_ulong) << 8) | nr as libc::c_ulong
-}
-
-const SINFO_IO_SETUP: libc::c_ulong = iow::<SinfoIoSetup>(0x01);
-const SINFO_IO_READ_REG: libc::c_ulong = iowr::<SinfoIoReg>(0x02);
-const SINFO_IO_READ_BATCH: libc::c_ulong = iowr::<SinfoIoBatch>(0x03);
+const SINFO_IO_SETUP:      libc::Ioctl = libc::_IOW::<SinfoIoSetup>(b'S' as u32, 0x01);
+const SINFO_IO_READ_REG:   libc::Ioctl = libc::_IOWR::<SinfoIoReg>(b'S' as u32, 0x02);
+const SINFO_IO_READ_BATCH: libc::Ioctl = libc::_IOWR::<SinfoIoBatch>(b'S' as u32, 0x03);
 
 // ── Kernel-matching structs ─────────────────────────────────────────────
 
@@ -215,17 +199,6 @@ impl HwmAccess {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_ioctl_numbers() {
-        // Verify our const fn ioctl encoding matches the C macro definitions.
-        // _IOW('S', 0x01, struct sinfo_io_setup) where sizeof = 4
-        assert_eq!(SINFO_IO_SETUP, 0x4004_5301);
-        // _IOWR('S', 0x02, struct sinfo_io_reg) where sizeof = 4
-        assert_eq!(SINFO_IO_READ_REG, 0xC004_5302);
-        // _IOWR('S', 0x03, struct sinfo_io_batch) where sizeof = 100
-        assert_eq!(SINFO_IO_READ_BATCH, 0xC064_5303);
-    }
 
     #[test]
     fn test_struct_sizes() {

--- a/src/platform/sinfo_io.rs
+++ b/src/platform/sinfo_io.rs
@@ -19,8 +19,8 @@ use super::port_io::PortIo;
 
 const SINFO_IO_BATCH_MAX: usize = 32;
 
-const SINFO_IO_SETUP:      libc::Ioctl = libc::_IOW::<SinfoIoSetup>(b'S' as u32, 0x01);
-const SINFO_IO_READ_REG:   libc::Ioctl = libc::_IOWR::<SinfoIoReg>(b'S' as u32, 0x02);
+const SINFO_IO_SETUP: libc::Ioctl = libc::_IOW::<SinfoIoSetup>(b'S' as u32, 0x01);
+const SINFO_IO_READ_REG: libc::Ioctl = libc::_IOWR::<SinfoIoReg>(b'S' as u32, 0x02);
 const SINFO_IO_READ_BATCH: libc::Ioctl = libc::_IOWR::<SinfoIoBatch>(b'S' as u32, 0x03);
 
 // ── Kernel-matching structs ─────────────────────────────────────────────

--- a/src/sensors/hsmp.rs
+++ b/src/sensors/hsmp.rs
@@ -11,12 +11,21 @@ mod inner {
 
     use crate::model::sensor::{SensorCategory, SensorId, SensorReading, SensorUnit};
 
+    #[repr(C, packed(4))]
+    struct HsmpMessage {
+        msg_id: u32,
+        num_args: u16,
+        response_sz: u16,
+        args: [u32; 8],
+        sock_ind: u16,
+    }
+
     // HSMP ioctl: _IOWR(0xF8, 0, hsmp_message)
     // The ioctl number encodes size=42 (the kernel's unpacked field sum).
     // Our #[repr(C, packed(4))] struct is 44 bytes due to trailing padding
     // on sock_ind (u16 → 4-byte boundary). The kernel reads 42 bytes via
     // copy_from_user, so the 2-byte tail padding is never accessed.
-    const HSMP_IOCTL: libc::c_ulong = 0xC02AF800;
+    const HSMP_IOCTL: libc::Ioctl = libc::_IOWR::<HsmpMessage>(0xF8, 0x0);
 
     // Message IDs
     const HSMP_TEST: u32 = 0x01;
@@ -29,15 +38,6 @@ mod inner {
     const HSMP_GET_DDR_BANDWIDTH: u32 = 0x14;
     const HSMP_GET_RAILS_SVI: u32 = 0x1B;
     const HSMP_GET_SOCKET_FMAX_FMIN: u32 = 0x1C;
-
-    #[repr(C, packed(4))]
-    struct HsmpMessage {
-        msg_id: u32,
-        num_args: u16,
-        response_sz: u16,
-        args: [u32; 8],
-        sock_ind: u16,
-    }
 
     pub struct HsmpSource {
         fd: Option<File>,

--- a/src/sensors/i2c/smbus_io.rs
+++ b/src/sensors/i2c/smbus_io.rs
@@ -2,9 +2,9 @@ use std::fs::{File, OpenOptions};
 use std::os::unix::io::AsRawFd;
 
 // Linux I2C ioctl request codes (from <linux/i2c-dev.h>)
-const I2C_SLAVE: libc::c_ulong = 0x0703;
-const I2C_SLAVE_FORCE: libc::c_ulong = 0x0706;
-const I2C_SMBUS: libc::c_ulong = 0x0720;
+const I2C_SLAVE: libc::Ioctl = 0x0703;
+const I2C_SLAVE_FORCE: libc::Ioctl = 0x0706;
+const I2C_SMBUS: libc::Ioctl = 0x0720;
 
 // SMBus transfer direction
 const I2C_SMBUS_READ: u8 = 1;


### PR DESCRIPTION
Switches to using the libc crate's built in functions and types for dealing with ioctl(), which allows for the project to be built against musl libc.

Removed some redundant tests now that libc::_IOW and libc::_IOWR are used to calculate the ioctl request.