### PR TITLE
Fix rapl subdomain only added once

### DIFF
--- a/src/collectors/cpu.rs
+++ b/src/collectors/cpu.rs
@@ -111,13 +111,13 @@ struct CpuidData {
 fn gather_cpuid() -> Option<CpuidData> {
     let cpuid = raw_cpuid::CpuId::new();
 
-    let vendor = match cpuid.get_vendor_info() {
-        Some(v) => match v.as_str() {
+    let vendor = {
+        let v = cpuid.get_vendor_info()?;
+        match v.as_str() {
             "GenuineIntel" => CpuVendor::Intel,
             "AuthenticAMD" => CpuVendor::Amd,
             other => CpuVendor::Unknown(other.to_string()),
-        },
-        None => return None,
+        }
     };
 
     let brand = cpuid

--- a/src/parsers/smbios.rs
+++ b/src/parsers/smbios.rs
@@ -291,7 +291,7 @@ fn read_u32_le(data: &[u8], offset: usize) -> Option<u32> {
 
 /// Read a non-zero u16 value; returns `None` for 0 or 0xFFFF (unknown).
 fn read_u16_nonzero(data: &[u8], offset: usize) -> Option<u16> {
-    read_u16_le(data, offset).and_then(|v| if v == 0 || v == 0xFFFF { None } else { Some(v) })
+    read_u16_le(data, offset).filter(|&v| !(v == 0 || v == 0xFFFF))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sensors/rapl.rs
+++ b/src/sensors/rapl.rs
@@ -1,5 +1,6 @@
 use crate::model::sensor::{SensorCategory, SensorId, SensorReading, SensorUnit};
 use crate::platform::sysfs::{self, CachedFile};
+use std::path::Path;
 use std::time::Instant;
 
 pub struct RaplSource {
@@ -14,18 +15,34 @@ struct RaplDomain {
     prev_time: Instant,
 }
 
+fn parse_domain(dir: &Path) -> Option<String> {
+    Some(
+        dir.to_str()?
+            .chars()
+            .skip_while(|c| !c.is_ascii_digit())
+            .take_while(|c| c.is_ascii_digit())
+            .collect::<String>(),
+    )
+}
+
 impl RaplSource {
     pub fn discover() -> Self {
         let mut domains = Vec::new();
 
         for dir in sysfs::glob_paths("/sys/class/powercap/intel-rapl:*") {
-            // Skip sub-domains like intel-rapl:0:1 at top level; we enumerate them
-            // separately via the glob which catches all levels.
+            // RAPL subdomains like intel-rapl:0:1 are included in the glob;
+            // in case the name of the subdomain does not have a distinctive number like `dram-0` a number will get added based on the RAPL domain.
             let name_path = dir.join("name");
-            let name = match sysfs::read_string_optional(&name_path) {
+            let mut name = match sysfs::read_string_optional(&name_path) {
                 Some(n) => n,
                 None => continue,
             };
+
+            if !name.chars().any(|c| c.is_ascii_digit())
+                && let Some(rapl_domain) = parse_domain(&dir)
+            {
+                name = format!("{name}-{rapl_domain}");
+            }
 
             let energy_path = dir.join("energy_uj");
             let max_path = dir.join("max_energy_range_uj");


### PR DESCRIPTION
Closes #70 

```bash
[root@cpl siomon]# ./target/release/sio sensors
── cpu/rapl ──
  RAPL dram-0                                5.8 W
  RAPL dram-1                                5.8 W
  RAPL dram-2                                5.0 W
  RAPL dram-3                                4.0 W
  RAPL package-0                            52.0 W
  RAPL package-1                            57.0 W
  RAPL package-2                            49.7 W
  RAPL package-3                            51.0 W
  ```

We now take the first integer we find which should be the domain and append it to the RAPL subdomain name.

```bash
[root@cpl powercap]# cat /sys/class/powercap/intel-rapl:0:0/name
dram -> dram-0
[root@cpl powercap]# cat /sys/class/powercap/intel-rapl:3:0/name
dram -> dram-3
```