### PR TITLE
Add parsing of distances between numa nodes

### DIFF
--- a/src/collectors/cpu.rs
+++ b/src/collectors/cpu.rs
@@ -605,10 +605,18 @@ fn gather_numa_nodes() -> Vec<NumaNode> {
         // Read NUMA node memory from its meminfo file.
         let memory_bytes = parse_numa_meminfo(&dir.join("meminfo"));
 
+        // Each field corresponds the distance to the numa node with the appropriate index
+        let distances = sysfs::read_string_optional(&dir.join("distance"))
+            .unwrap_or_default()
+            .split_whitespace()
+            .filter_map(|s| s.parse::<u32>().ok())
+            .collect::<Vec<u32>>();
+
         nodes.push(NumaNode {
             node_id,
             cpu_list,
             memory_bytes,
+            distances,
         });
     }
 

--- a/src/model/cpu.rs
+++ b/src/model/cpu.rs
@@ -56,6 +56,7 @@ pub struct NumaNode {
     pub node_id: u32,
     pub cpu_list: String,
     pub memory_bytes: Option<u64>,
+    pub distances: Vec<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Here we add the parsing of the distances between NUMA nodes.

There is an argument to be made that the field in the struct should be named `distance` and not distances as the field in the sysfs is `distance`. If requested I can change that.

```bash
$ numactl -H
node distances:
node     0    1 
   0:   10   20 
   1:   20   10 
$ ./target/result/sio cpu
...
 topology: CpuTopology {
       ...
        numa_nodes: [
            NumaNode {
                node_id: 0,
                cpu_list: "0-35,72-107",
                memory_bytes: Some(
                    270133071872,
                ),
                distances: [
                    10,
                    20,
                ],
            },
            NumaNode {
                node_id: 1,
                cpu_list: "36-71,108-143",
                memory_bytes: Some(
                    270499954688,
                ),
                distances: [
                    20,
                    10,
                ],
            },
        ],
        online_cpus: "0-143",
    },
    ...
```

For each numa node the array looks as follows:

```
nodeId: 2
distances: [ distance to node 0, distance to node1, distance to node2, distance to node3, ...]
```

Therefore, we would get the distance to ourselves like:

```
nodeId: 2
distances[2] = <value>
```